### PR TITLE
Add extensible command-driven multiplayer server

### DIFF
--- a/client.py
+++ b/client.py
@@ -10,6 +10,8 @@ class Client:
     def __init__(self, uri):
         self.uri = uri
         self.players = {}
+        self.player_id = None
+        self.available_commands = {}
         self.x = 0
         self.y = 0
         pygame.init()
@@ -18,7 +20,7 @@ class Client:
         self.clock = pygame.time.Clock()
 
     async def send_move(self, websocket, move):
-        await websocket.send(json.dumps({'move': move}))
+        await websocket.send(json.dumps({'type': 'move', 'direction': move}))
 
     async def run(self):
         async with websockets.connect(self.uri) as websocket:
@@ -26,12 +28,23 @@ class Client:
             async def receiver():
                 async for message in websocket:
                     data = json.loads(message)
-                    self.players = data.get('players', {})
-                    # Update own position
-                    ws_id = str(id(websocket))
-                    if ws_id in self.players:
-                        self.x = self.players[ws_id]['x']
-                        self.y = self.players[ws_id]['y']
+                    msg_type = data.get('type')
+                    if msg_type == 'welcome':
+                        self.player_id = data.get('playerId')
+                        self.available_commands = data.get('commands', {})
+                        if self.available_commands:
+                            print('Available commands:')
+                            for name, description in self.available_commands.items():
+                                print(f" - {name}: {description}")
+                    elif msg_type == 'state':
+                        self.players = data.get('players', {})
+                        if self.player_id and self.player_id in self.players:
+                            self.x = self.players[self.player_id]['x']
+                            self.y = self.players[self.player_id]['y']
+                    elif msg_type == 'error':
+                        print(f"Server error: {data.get('message')}")
+                    elif msg_type == 'pong':
+                        print('Received pong from server', data.get('echo', ''))
 
             recv_task = asyncio.create_task(receiver())
             running = True
@@ -55,7 +68,7 @@ class Client:
                 offset_y = HEIGHT // 2 - self.y
                 # Draw players
                 for ws_id, pos in self.players.items():
-                    color = (255, 0, 0) if ws_id == str(id(websocket)) else (0, 255, 0)
+                    color = (255, 0, 0) if self.player_id and ws_id == self.player_id else (0, 255, 0)
                     pygame.draw.circle(
                         self.screen,
                         color,

--- a/server.py
+++ b/server.py
@@ -15,7 +15,7 @@ HEIGHT = 1000
 class Command:
     """Represents a command that can be executed by the server."""
 
-    handler: Callable[["MultiPurposeServer", websockets.WebSocketServerProtocol, dict], Awaitable[None]]
+    handler: Callable[[websockets.WebSocketServerProtocol, dict], Awaitable[None]]
     description: str
 
 
@@ -28,7 +28,7 @@ class CommandRegistry:
     def register(
         self,
         name: str,
-        handler: Callable[["MultiPurposeServer", websockets.WebSocketServerProtocol, dict], Awaitable[None]],
+        handler: Callable[[websockets.WebSocketServerProtocol, dict], Awaitable[None]],
         *,
         description: str,
     ) -> None:
@@ -110,7 +110,7 @@ class MultiPurposeServer:
             await self._send_error(websocket, f"Unknown command '{command_name}'.")
             return
 
-        await command.handler(self, websocket, data)
+        await command.handler(websocket, data)
 
     # ------------------------------------------------------------------
     # Command handlers

--- a/server.py
+++ b/server.py
@@ -1,49 +1,219 @@
 import asyncio
 import json
 import random
+import uuid
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Dict, Optional
+
 import websockets
 
 WIDTH = 1000
 HEIGHT = 1000
 
-players = {}
 
-async def notify_state():
-    state = {ws_id: {'x': pos[0], 'y': pos[1]} for ws_id, pos in players.items()}
-    if players:
-        msg = json.dumps({'players': state})
-        await asyncio.wait([ws.send(msg) for ws in players])
+@dataclass
+class Command:
+    """Represents a command that can be executed by the server."""
 
-async def handler(websocket):
-    # Assign random position
-    x = random.randint(0, WIDTH)
-    y = random.randint(0, HEIGHT)
-    players[websocket] = [x, y]
-    await notify_state()
-    try:
-        async for message in websocket:
+    handler: Callable[["MultiPurposeServer", websockets.WebSocketServerProtocol, dict], Awaitable[None]]
+    description: str
+
+
+class CommandRegistry:
+    """Registry used to keep track of commands that the server supports."""
+
+    def __init__(self) -> None:
+        self._commands: Dict[str, Command] = {}
+
+    def register(
+        self,
+        name: str,
+        handler: Callable[["MultiPurposeServer", websockets.WebSocketServerProtocol, dict], Awaitable[None]],
+        *,
+        description: str,
+    ) -> None:
+        self._commands[name] = Command(handler=handler, description=description)
+
+    def get(self, name: str) -> Optional[Command]:
+        return self._commands.get(name)
+
+    def help_text(self) -> Dict[str, str]:
+        return {name: command.description for name, command in sorted(self._commands.items())}
+
+
+class MultiPurposeServer:
+    """WebSocket server that supports an extensible command system."""
+
+    def __init__(self, width: int = WIDTH, height: int = HEIGHT) -> None:
+        self.width = width
+        self.height = height
+        self.players: Dict[websockets.WebSocketServerProtocol, dict] = {}
+        self.commands = CommandRegistry()
+        self._register_default_commands()
+
+    # ------------------------------------------------------------------
+    # Connection helpers
+    # ------------------------------------------------------------------
+    async def handler(self, websocket: websockets.WebSocketServerProtocol) -> None:
+        player_id = uuid.uuid4().hex
+        player_state = {
+            "id": player_id,
+            "x": random.randint(0, self.width),
+            "y": random.randint(0, self.height),
+        }
+        self.players[websocket] = player_state
+        await self._send(
+            websocket,
+            {
+                "type": "welcome",
+                "playerId": player_id,
+                "commands": self.commands.help_text(),
+            },
+        )
+        await self._broadcast_state()
+
+        try:
+            async for message in websocket:
+                await self._handle_message(websocket, message)
+        finally:
+            self.players.pop(websocket, None)
+            await self._broadcast_state()
+
+    async def _handle_message(self, websocket: websockets.WebSocketServerProtocol, message: str) -> None:
+        try:
             data = json.loads(message)
-            dx, dy = 0, 0
-            if data.get('move') == 'up':
-                dy = -5
-            elif data.get('move') == 'down':
-                dy = 5
-            elif data.get('move') == 'left':
-                dx = -5
-            elif data.get('move') == 'right':
-                dx = 5
-            pos = players[websocket]
-            pos[0] = max(0, min(WIDTH, pos[0] + dx))
-            pos[1] = max(0, min(HEIGHT, pos[1] + dy))
-            await notify_state()
-    finally:
-        del players[websocket]
-        await notify_state()
+        except json.JSONDecodeError:
+            await self._send_error(websocket, "Received invalid JSON data.")
+            return
 
-async def main():
-    async with websockets.serve(handler, '0.0.0.0', 8765):
-        print('Server started on port 8765')
+        if not isinstance(data, dict):
+            await self._send_error(websocket, "Messages must be JSON objects.")
+            return
+
+        command_name = data.get("type") or data.get("command")
+        if not command_name and "move" in data:
+            command_name = "move"
+
+        if not command_name:
+            await self._send_error(websocket, "Missing command type in message.")
+            return
+
+        if command_name == "help":
+            await self._send(
+                websocket,
+                {"type": "help", "commands": self.commands.help_text()},
+            )
+            return
+
+        command = self.commands.get(command_name)
+        if not command:
+            await self._send_error(websocket, f"Unknown command '{command_name}'.")
+            return
+
+        await command.handler(self, websocket, data)
+
+    # ------------------------------------------------------------------
+    # Command handlers
+    # ------------------------------------------------------------------
+    def _register_default_commands(self) -> None:
+        self.commands.register(
+            "move",
+            self._command_move,
+            description="Move the player. Use the 'direction' or 'move' field with up/down/left/right.",
+        )
+        self.commands.register(
+            "ping",
+            self._command_ping,
+            description="Check connectivity. Optionally include an 'echo' field to be returned.",
+        )
+        self.commands.register(
+            "state",
+            self._command_state,
+            description="Receive the latest player positions without broadcasting to others.",
+        )
+
+    async def _command_move(self, websocket: websockets.WebSocketServerProtocol, data: dict) -> None:
+        player = self.players.get(websocket)
+        if not player:
+            return
+
+        direction = data.get("direction") or data.get("move")
+        if not direction:
+            await self._send_error(websocket, "Missing 'direction' for move command.")
+            return
+
+        dx, dy = 0, 0
+        if direction == "up":
+            dy = -5
+        elif direction == "down":
+            dy = 5
+        elif direction == "left":
+            dx = -5
+        elif direction == "right":
+            dx = 5
+        else:
+            await self._send_error(websocket, f"Unknown move direction '{direction}'.")
+            return
+
+        player["x"] = max(0, min(self.width, player["x"] + dx))
+        player["y"] = max(0, min(self.height, player["y"] + dy))
+        await self._broadcast_state()
+
+    async def _command_ping(self, websocket: websockets.WebSocketServerProtocol, data: dict) -> None:
+        payload = {"type": "pong"}
+        if "echo" in data:
+            payload["echo"] = data["echo"]
+        await self._send(websocket, payload)
+
+    async def _command_state(self, websocket: websockets.WebSocketServerProtocol, data: dict) -> None:
+        await self._send(websocket, self._build_state_message())
+
+    # ------------------------------------------------------------------
+    # Messaging helpers
+    # ------------------------------------------------------------------
+    async def _send(self, websocket: websockets.WebSocketServerProtocol, payload: dict) -> None:
+        try:
+            await websocket.send(json.dumps(payload))
+        except websockets.ConnectionClosed:
+            pass
+
+    async def _broadcast_state(self) -> None:
+        if not self.players:
+            return
+        message = json.dumps(self._build_state_message())
+        await asyncio.gather(
+            *(
+                self._safe_send(websocket, message)
+                for websocket in list(self.players.keys())
+            ),
+            return_exceptions=True,
+        )
+
+    async def _safe_send(self, websocket: websockets.WebSocketServerProtocol, message: str) -> None:
+        try:
+            await websocket.send(message)
+        except websockets.ConnectionClosed:
+            self.players.pop(websocket, None)
+
+    async def _send_error(self, websocket: websockets.WebSocketServerProtocol, message: str) -> None:
+        await self._send(websocket, {"type": "error", "message": message})
+
+    def _build_state_message(self) -> dict:
+        return {
+            "type": "state",
+            "players": {
+                player_state["id"]: {"x": player_state["x"], "y": player_state["y"]}
+                for player_state in self.players.values()
+            },
+        }
+
+
+async def main() -> None:
+    server = MultiPurposeServer()
+    async with websockets.serve(server.handler, "0.0.0.0", 8765):
+        print("Server started on port 8765")
         await asyncio.Future()  # run forever
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- refactor the websocket server into a reusable `MultiPurposeServer` with a command registry and built-in commands
- send structured welcome, state, error, and pong messages to support future functionality
- update the client to use the new protocol and surface available commands to the console

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_6908d53160a0832c8395adbc2261a961