### PR TITLE
Add server-side roaming AI boss and client rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ Start one or more clients (in separate terminals) after the server is running:
 python client.py
 ```
 Use the arrow keys to move your player around the world.
+
+## AI
+The server spawns a large AI-controlled boss that roams the world without relying on any external models.

--- a/client.py
+++ b/client.py
@@ -10,6 +10,8 @@ class Client:
     def __init__(self, uri):
         self.uri = uri
         self.players = {}
+        self.ais = {}
+        self.self_id = None
         self.x = 0
         self.y = 0
         pygame.init()
@@ -27,11 +29,12 @@ class Client:
                 async for message in websocket:
                     data = json.loads(message)
                     self.players = data.get('players', {})
+                    self.ais = data.get('ais', {})
+                    self.self_id = data.get('self_id')
                     # Update own position
-                    ws_id = str(id(websocket))
-                    if ws_id in self.players:
-                        self.x = self.players[ws_id]['x']
-                        self.y = self.players[ws_id]['y']
+                    if self.self_id in self.players:
+                        self.x = self.players[self.self_id]['x']
+                        self.y = self.players[self.self_id]['y']
 
             recv_task = asyncio.create_task(receiver())
             running = True
@@ -55,12 +58,19 @@ class Client:
                 offset_y = HEIGHT // 2 - self.y
                 # Draw players
                 for ws_id, pos in self.players.items():
-                    color = (255, 0, 0) if ws_id == str(id(websocket)) else (0, 255, 0)
+                    color = (255, 0, 0) if ws_id == self.self_id else (0, 255, 0)
                     pygame.draw.circle(
                         self.screen,
                         color,
                         (pos['x'] + offset_x, pos['y'] + offset_y),
                         10
+                    )
+                for ai_id, pos in self.ais.items():
+                    pygame.draw.circle(
+                        self.screen,
+                        (0, 128, 255),
+                        (pos['x'] + offset_x, pos['y'] + offset_y),
+                        pos.get('size', 30)
                     )
                 pygame.display.flip()
                 self.clock.tick(60)

--- a/server.py
+++ b/server.py
@@ -5,45 +5,85 @@ import websockets
 
 WIDTH = 1000
 HEIGHT = 1000
+AI_ID = "ai_boss"
 
 players = {}
+connections = {}
+ai_state = {"x": WIDTH // 2, "y": HEIGHT // 2, "size": 40}
+ai_target = {"x": WIDTH // 2, "y": HEIGHT // 2}
+
+
+def clamp_position(value, min_value, max_value):
+    return max(min_value, min(max_value, value))
+
 
 async def notify_state():
-    state = {ws_id: {'x': pos[0], 'y': pos[1]} for ws_id, pos in players.items()}
-    if players:
-        msg = json.dumps({'players': state})
-        await asyncio.wait([ws.send(msg) for ws in players])
+    if not connections:
+        return
+    state = {player_id: {"x": pos[0], "y": pos[1]} for player_id, pos in players.items()}
+    msg_base = {"players": state, "ais": {AI_ID: ai_state}}
+    tasks = []
+    for websocket, player_id in connections.items():
+        payload = dict(msg_base)
+        payload["self_id"] = player_id
+        tasks.append(websocket.send(json.dumps(payload)))
+    if tasks:
+        await asyncio.gather(*tasks)
+
 
 async def handler(websocket):
-    # Assign random position
+    player_id = str(id(websocket))
     x = random.randint(0, WIDTH)
     y = random.randint(0, HEIGHT)
-    players[websocket] = [x, y]
+    players[player_id] = [x, y]
+    connections[websocket] = player_id
     await notify_state()
     try:
         async for message in websocket:
             data = json.loads(message)
             dx, dy = 0, 0
-            if data.get('move') == 'up':
+            if data.get("move") == "up":
                 dy = -5
-            elif data.get('move') == 'down':
+            elif data.get("move") == "down":
                 dy = 5
-            elif data.get('move') == 'left':
+            elif data.get("move") == "left":
                 dx = -5
-            elif data.get('move') == 'right':
+            elif data.get("move") == "right":
                 dx = 5
-            pos = players[websocket]
-            pos[0] = max(0, min(WIDTH, pos[0] + dx))
-            pos[1] = max(0, min(HEIGHT, pos[1] + dy))
+            pos = players[player_id]
+            pos[0] = clamp_position(pos[0] + dx, 0, WIDTH)
+            pos[1] = clamp_position(pos[1] + dy, 0, HEIGHT)
             await notify_state()
     finally:
-        del players[websocket]
+        players.pop(player_id, None)
+        connections.pop(websocket, None)
         await notify_state()
 
+
+async def ai_loop():
+    global ai_target
+    while True:
+        if abs(ai_state["x"] - ai_target["x"]) < 5 and abs(ai_state["y"] - ai_target["y"]) < 5:
+            ai_target = {"x": random.randint(0, WIDTH), "y": random.randint(0, HEIGHT)}
+        step = 3
+        if ai_state["x"] < ai_target["x"]:
+            ai_state["x"] = clamp_position(ai_state["x"] + step, 0, WIDTH)
+        elif ai_state["x"] > ai_target["x"]:
+            ai_state["x"] = clamp_position(ai_state["x"] - step, 0, WIDTH)
+        if ai_state["y"] < ai_target["y"]:
+            ai_state["y"] = clamp_position(ai_state["y"] + step, 0, HEIGHT)
+        elif ai_state["y"] > ai_target["y"]:
+            ai_state["y"] = clamp_position(ai_state["y"] - step, 0, HEIGHT)
+        await notify_state()
+        await asyncio.sleep(0.1)
+
+
 async def main():
-    async with websockets.serve(handler, '0.0.0.0', 8765):
-        print('Server started on port 8765')
+    async with websockets.serve(handler, "0.0.0.0", 8765):
+        print("Server started on port 8765")
+        asyncio.create_task(ai_loop())
         await asyncio.Future()  # run forever
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
### Motivation
- Introduce a large AI-controlled boss that roams the world to make the multiplayer demo more dynamic. 
- Ensure the AI is implemented on the server and does not rely on any external models or services. 
- Provide per-connection metadata so each client can identify its own player and receive AI state. 

### Description
- Added server-side AI state and an `ai_loop` that picks random targets and moves the AI boss incrementally, plus a `clamp_position` helper to bound positions. 
- Changed server message payloads to include `ais` and a per-connection `self_id`, and replaced the previous websocket-keyed player map with string player IDs and a `connections` mapping. 
- Updated the client to track `ais` and `self_id`, render AI bosses as blue circles, and use `self_id` for highlighting the local player. 
- Documented the new AI boss behavior in `README.md`. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970cc51f32c832c9e9046d0ee7f1de7)